### PR TITLE
npm install시 production만 하도록 변경

### DIFF
--- a/.github/workflows/deploy-api.yaml
+++ b/.github/workflows/deploy-api.yaml
@@ -34,7 +34,6 @@ jobs:
       - name: Pack
         run: |
           cd ./apps/api
-          mkdir node_modules
           zip -r ../../${{github.run_id}}.zip .
 
       - name: Upload Artifacts


### PR DESCRIPTION
https://stackoverflow.com/questions/20552373/how-does-aws-beanstalk-use-npm-when-deploying-a-nodejs-app