### PR TITLE
[진행중] tags 데이터 추가 전송 및 클라이언트 컴포넌트에서 서버 컴포넌트 호출 오류 수정

### DIFF
--- a/apps/web/action/updateReviewAction.ts
+++ b/apps/web/action/updateReviewAction.ts
@@ -1,20 +1,22 @@
-"use server";
+'use server';
 
-import { revalidatePath } from "next/cache";
-import { cookies } from "next/headers";
+import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
 
 export async function updateReviewAction(_: any, formData: FormData) {
-  const reviewId = formData.get("reviewId")?.toString();
-  const title = formData.get("title")?.toString();
-  const content = formData.get("content")?.toString();
-  const categoryId = formData.get("categoryId")?.toString();
-  const visibility = formData.get("visibility")?.toString();
-  const rating = formData.get("rating")?.toString();
+  const reviewId = formData.get('reviewId')?.toString();
+  const title = formData.get('title')?.toString();
+  const content = formData.get('content')?.toString();
+  const categoryId = formData.get('categoryId')?.toString();
+  const visibility = formData.get('visibility')?.toString();
+  const rating = formData.get('rating')?.toString();
+  const tags = formData.get('tags')?.toString();
+  const links = formData.get('links')?.toString();
 
   if (!title || !content || !categoryId || !visibility || !rating) {
     return {
       status: false,
-      error: "필수 필드를 모두 입력해 주세요.",
+      error: '필수 필드를 모두 입력해 주세요.',
     };
   }
 
@@ -24,29 +26,30 @@ export async function updateReviewAction(_: any, formData: FormData) {
     categoryId: parseInt(categoryId),
     visibility,
     rating,
+    tags: tags.split(' '),
   };
 
   try {
-    const token = cookies().get("token")?.value;
+    const token = cookies().get('token')?.value;
     const result = await fetch(
       `http://localhost:3000/reviews/${parseInt(reviewId)}`,
       {
-        method: "PUT",
+        method: 'PUT',
         headers: {
-          "content-type": "application/json",
+          'content-type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
-        credentials: "include",
+        credentials: 'include',
         body: JSON.stringify(data),
       }
     );
     if (!result.ok) {
       throw new Error(result.statusText);
     }
-
+    revalidatePath('/reviews');
     return {
       status: true,
-      message: "리뷰 수정에 성공했습니다.",
+      error: '리뷰 수정에 성공했습니다.',
     };
   } catch (err) {
     return {

--- a/apps/web/app/(reviews)/reviews/[id]/edit/page.tsx
+++ b/apps/web/app/(reviews)/reviews/[id]/edit/page.tsx
@@ -5,15 +5,15 @@ import Form from '../../_form';
 export default async function Page({ params: { id } }) {
   const token = cookies().get('token')?.value;
   const url = new URL(`/reviews/${id}`, process.env.API_ORIGIN);
-  const response = await fetch(url,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-  const review = await response.json();
+  const categoriesUrl = new URL('/categories', process.env.API_ORIGIN);
 
-  return (
-    <Form review={review} />
-  );
+  const [reviewResponse, categoriesResponse] = await Promise.all([
+    fetch(url, { headers: { Authorization: `Bearer ${token}` } }),
+    fetch(categoriesUrl, { headers: { Authorization: `Bearer ${token}` } }),
+  ]);
+
+  const review = await reviewResponse.json();
+  const categories = await categoriesResponse.json();
+
+  return <Form review={review} categories={categories} />;
 }

--- a/apps/web/app/(reviews)/reviews/_form.tsx
+++ b/apps/web/app/(reviews)/reviews/_form.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useState, useActionState } from 'react';
+import { useState, useActionState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { StarIcon } from '@heroicons/react/24/solid';
 import { StarIcon as OutlineStarIcon } from '@heroicons/react/24/outline';
 import {
@@ -7,18 +8,24 @@ import {
   Input,
   Textarea,
   FixedActionButton,
+  Select,
 } from '@i-review-you/react-components';
-
-import Categories from './_form-categories';
 
 import { updateReviewAction } from '../../../action/updateReviewAction';
 import { createReviewAction } from './action';
 
-export default function Form({ review }) {
+export default function Form({ review, categories }) {
+  const router = useRouter();
   const [state, formAction, isPending] = useActionState(
     review?.id ? updateReviewAction : createReviewAction,
     {}
   );
+
+  useEffect(() => {
+    if (state?.status === true) {
+      router.push('/reviews');
+    }
+  }, [state, router]);
 
   return (
     <form
@@ -29,7 +36,13 @@ export default function Form({ review }) {
         {review?.id && (
           <input type="hidden" name="reviewId" value={review.id} readOnly />
         )}
-        <Categories />
+        <Select
+          name="categoryId"
+          options={categories.map((category) => ({
+            value: category.id,
+            label: category.name,
+          }))}
+        />
         <Input
           name="title"
           placeholder="제목을 입력하세요"
@@ -44,8 +57,12 @@ export default function Form({ review }) {
         {/* <div> */}
         {/*  <Input type="file" name="imageUpload" placeholder="이미지 업로드" /> */}
         {/* </div> */}
-        {/* <Input name="tag" placeholder="태그" /> */}
-        {/* <Input name="link" placeholder="링크추가" /> */}
+        <Input
+          name="tags"
+          placeholder="태그"
+          defaultValue={review?.review_tags.map((tag) => tag.name).join(' ')}
+        />
+        {/* <Input name="links" placeholder="링크추가" /> */}
         <WriteVisibility defaultValue={review?.visibility} />
         <WriteRating defaultValue={review?.rating} />
       </div>

--- a/apps/web/app/(reviews)/reviews/action.ts
+++ b/apps/web/app/(reviews)/reviews/action.ts
@@ -9,6 +9,8 @@ export async function createReviewAction(_: any, formData: FormData) {
   const categoryId = formData.get('categoryId')?.toString();
   const visibility = formData.get('visibility')?.toString();
   const rating = formData.get('rating')?.toString();
+  const tags = formData.get('tags')?.toString();
+  const links = formData.get('links')?.toString();
 
   if (!title || !content || !categoryId || !visibility || !rating) {
     return {
@@ -23,6 +25,7 @@ export async function createReviewAction(_: any, formData: FormData) {
     categoryId: parseInt(categoryId),
     visibility,
     rating,
+    tags: tags.split(' '),
   };
 
   try {
@@ -31,7 +34,7 @@ export async function createReviewAction(_: any, formData: FormData) {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'Authorization': `Bearer ${token}`,
+        Authorization: `Bearer ${token}`,
       },
       credentials: 'include',
       body: JSON.stringify(data),
@@ -40,13 +43,12 @@ export async function createReviewAction(_: any, formData: FormData) {
     if (!result.ok) {
       throw new Error(result.statusText);
     }
-
+    revalidatePath('/reviews');
     return {
       status: true,
-      message: '리뷰 작성에 성공했습니다.',
+      error: '리뷰 작성에 성공했습니다.',
     };
-  }
-  catch (err) {
+  } catch (err) {
     return {
       status: false,
       error: `리뷰 작성에 실패했습니다. ${err}`,

--- a/apps/web/app/(reviews)/reviews/create/page.tsx
+++ b/apps/web/app/(reviews)/reviews/create/page.tsx
@@ -9,7 +9,17 @@ export default async function Page({ params: { id } }) {
     redirect('/login');
   }
 
+  const url = new URL('/categories', process.env.API_ORIGIN);
+  const response = await fetch(url, {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  });
+  const categories = await response.json();
+
   return (
-    <Form />
+    <>
+      <Form categories={categories} />
+    </>
   );
 }


### PR DESCRIPTION
## 변경 사항
- tags 데이터를 추가로 전송하도록 구현
- 클라이언트 컴포넌트(Form)에서 서버 컴포넌트(Categories) 호출 시 발생한 오류 수정

## 추후 작업 및 확인 필요
- tags 등록 UI 방식 확정 (공백 또는 "," 등 다양한 구분자를 사용해 태그 처리)
- 리뷰 수정 시 서버에서 기존 태그와 중복되지 않도록 처리 필요 (중복 태그 제거)
- links UI에서 사용자로부터 link name과 href를 받아서 올바르게 전송할 수 있도록 개선
- Categories 컴포넌트를 별도로 분리해 재사용성을 높이는 방안 검토