### PR TITLE
Feat: 마이페이지 조회 및 수정, 팔로잉 및 팔로워 조회 기능 추가

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,9 +6,10 @@ import { AuthModule } from './auth/auth.module';
 import { CategoriesModule } from './categories/categories.module';
 import { LikesModule } from './likes/likes.module';
 import { UsersModule } from './users/users.module';
+import { MyPageModule } from './mypage/mypage.module';
 
 @Module({
-  imports: [ReviewsModule, AuthModule, CategoriesModule, LikesModule, UsersModule],
+  imports: [ReviewsModule, AuthModule, CategoriesModule, LikesModule, UsersModule, MyPageModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/api/src/mypage/mypage.controller.ts
+++ b/apps/api/src/mypage/mypage.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  UseGuards,
+  Get,
+  Put,
+  Body,
+} from '@nestjs/common';
+
+import { AuthGuard } from '../auth/auth.guard';
+import { MyPageService } from './mypage.service';
+import { GetCurrentUser } from '../auth/auth.decorator';
+
+@Controller('mypage')
+export class MyPageController {
+  constructor(private readonly myPageService: MyPageService) {}
+
+  @Get()
+  @UseGuards(AuthGuard)
+  async getMyPage(@GetCurrentUser() user) {
+    const profile = await this.myPageService.getProfile(user);
+    const followings = await this.myPageService.getFollowingCount(user);
+    const followers = await this.myPageService.getFollowerCount(user);
+    const reviews = await this.myPageService.getReviewCount(user);
+
+    return { ...profile, followings, followers, reviews };
+  }
+
+  @Put()
+  @UseGuards(AuthGuard)
+  async updateMyPage(@GetCurrentUser() user, @Body() body) {
+    return await this.myPageService.updateProfile(user, { ...body });
+  }
+
+  @Get('following')
+  @UseGuards(AuthGuard)
+  async getFollowing(@GetCurrentUser() user) {
+    return await this.myPageService.getFollowing(user);
+  }
+
+  @Get('follower')
+  @UseGuards(AuthGuard)
+  async getFollower(@GetCurrentUser() user) {
+    return await this.myPageService.getFollower(user);
+  }
+}

--- a/apps/api/src/mypage/mypage.module.ts
+++ b/apps/api/src/mypage/mypage.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { MyPageService } from './mypage.service';
+import { MyPageController } from './mypage.controller';
+import { AuthService } from '../auth/auth.service';
+
+@Module({
+  controllers: [MyPageController],
+  providers: [AuthService, MyPageService],
+})
+export class MyPageModule {}

--- a/apps/api/src/mypage/mypage.service.ts
+++ b/apps/api/src/mypage/mypage.service.ts
@@ -1,0 +1,164 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { HttpException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient('https://algsfyxfsvqgthqbmwzr.supabase.co', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFsZ3NmeXhmc3ZxZ3RocWJtd3pyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MjYxMTEyODgsImV4cCI6MjA0MTY4NzI4OH0.7Y2QUFRraSGmt3NWbSGSUflMx71kjxWCVo8jA5EWjII');
+
+@Injectable()
+export class MyPageService {
+  async getProfile(user) {
+    const { data, error } = await supabase
+      .from('profile')
+      .select(`
+        username,
+        avatarUrl:avatar_url,
+        name,
+        biography
+      `)
+      .eq('user_id', user.id)
+      .limit(1)
+      .single();
+
+    if (error) {
+      throw new HttpException({
+        message: error.message,
+      }, HttpStatus.BAD_REQUEST, { cause: error });
+    }
+
+    return data;
+  }
+
+  async getFollowingCount(user) {
+    const { count, error } = await supabase
+      .from('follows')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .is('deleted_at', null);
+
+    if (error) {
+      throw new HttpException({
+        message: error.message,
+      }, HttpStatus.BAD_REQUEST, { cause: error });
+    }
+
+    return count;
+  }
+
+  async getFollowerCount(user) {
+    const { count, error } = await supabase
+      .from('follows')
+      .select('*', { count: 'exact', head: true })
+      .eq('following_id', user.id)
+      .is('deleted_at', null);
+
+    if (error) {
+      throw new HttpException({
+        message: error.message,
+      }, HttpStatus.BAD_REQUEST, { cause: error });
+    }
+
+    return count;
+  }
+
+  async getReviewCount(user) {
+    const { count, error } = await supabase
+      .from('reviews')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .is('deleted_at', null);
+
+    if (error) {
+      throw new HttpException({
+        message: error.message,
+      }, HttpStatus.BAD_REQUEST, { cause: error });
+    }
+
+    return count;
+  }
+
+  async getFollowing(user) {
+    const sqlQuery = `
+      SELECT jsonb_agg(row_to_json(t))
+      FROM (
+        SELECT username, name, biography
+        FROM profile
+        JOIN follows
+        ON profile.user_id = follows.following_id
+        WHERE follows.user_id = $1
+        AND follows.deleted_at IS NULL
+      ) AS t;      
+    `;
+    const { data, error } = await supabase
+      .rpc('execute_sql', { sql: sqlQuery, params: user.id });
+
+    if (error) {
+      throw new HttpException({
+        message: error,
+      }, HttpStatus.BAD_REQUEST, { cause: error });
+    }
+
+    return data;
+  }
+
+  async getFollower(user) {
+    const sqlQuery = `
+      SELECT jsonb_agg(row_to_json(t))
+      FROM (
+        SELECT username, name, biography
+        FROM profile
+        JOIN follows
+        ON profile.user_id = follows.following_id
+        WHERE follows.following_id = $1
+        AND follows.deleted_at IS NULL
+      ) AS t;      
+    `;
+    const { data, error } = await supabase
+      .rpc('execute_sql', { sql: sqlQuery, params: user.id });
+
+    if (error) {
+      throw new HttpException({
+        message: error.message,
+      }, HttpStatus.BAD_REQUEST, { cause: error });
+    }
+
+    return data;
+  }
+
+  async getReviews(user) {
+    const { data, error } = await supabase
+      .from('reviews')
+      .select(`
+        
+      `)
+      .eq('user_id', user.id)
+      .is('deleted_at', null);
+
+    if (error) {
+      throw new HttpException({
+        message: error.message,
+      }, HttpStatus.BAD_REQUEST, { cause: error });
+    }
+
+    return data;
+  }
+
+  async updateProfile(user, { username, name, biography }) {
+    const { data, error } = await supabase
+      .from('profile')
+      .update({
+        username,
+        name,
+        biography,
+      })
+      .eq('user_id', user.id)
+      .select();
+
+    if (error) {
+      throw new HttpException({
+        message: error.message,
+      }, HttpStatus.BAD_REQUEST, { cause: error });
+    }
+
+    return data;
+  }
+}


### PR DESCRIPTION
1. 마이페이지 조회 및 수정 API 추가
-> 마이페이지 조회: profile 테이블 이외에도 팔로잉 수, 팔로워 수, 리뷰 수 조회 가능
-> 마이페이지 수정: profile 테이블만 수정
2. 사용자의 팔로잉 및 팔로워 리스트 조회 API 추가

